### PR TITLE
Fix constraint tables and schema normalization

### DIFF
--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -270,6 +270,7 @@ class ConstraintDict(DbObjectDict):
         for constr in self.fetch():
             constr.unqualify()
             sch, tbl, cns = constr.key()
+            sch, tbl = split_schema_obj('%s.%s' % (sch, tbl));
             constr_type = constr.type
             del constr.type
             if constr_type != 'f':


### PR DESCRIPTION
For constraints, some identifiers can be returned with double quotes in their name (example: a table name public."order").
