### PR TITLE
Fix small bug on "create foreign data wrapper" statement.

### DIFF
--- a/pyrseas/dbobject/foreign.py
+++ b/pyrseas/dbobject/foreign.py
@@ -27,7 +27,7 @@ class ForeignDataWrapper(DbObject):
         if hasattr(self, 'options'):
             opts = []
             for opt in self.options:
-                (nm, val) = opt.split('=')
+                (nm, val) = opt.split('=', 1)
                 opts.append("%s '%s'" % (nm, val))
             clauses.append("OPTIONS (%s)" % ', '.join(opts))
         stmts = ["CREATE FOREIGN DATA WRAPPER %s%s" % (


### PR DESCRIPTION
When an option value contains the '=' character, the code would fail because opt.split('=') would return a list bigger than 2 items.
