### PR TITLE
dbtoyaml: some improvements in controlling output

### DIFF
--- a/pyrseas/dbtoyaml.py
+++ b/pyrseas/dbtoyaml.py
@@ -19,10 +19,15 @@ def main(host='localhost', port=5432, schema=None):
     parser = ArgumentParser(parents=[parent_parser()],
                             description="Extract the schema of a PostgreSQL "
                             "database in YAML format")
-    parser.add_argument('-n', '--schema',
+    parser.add_argument('-n', '--schema', action='append', default=[],
                         help="only for named schema (default %(default)s)")
+    parser.add_argument('-N', '--exclude-schema', action='append', default=[],
+                        help='exclude one or more database schemas')
     parser.add_argument('-t', '--table', dest='tablist', action='append',
-                     help="only for named tables (default all)")
+                        default=[], help="only for named tables (default all)")
+    parser.add_argument('-T', '--exclude-table', dest='ex_tablist',
+                        action='append', default=[],
+                        help='exclude one or more database tables')
 
     parser.set_defaults(host=host, port=port, username=os.getenv("USER"),
                         schema=schema)
@@ -30,7 +35,9 @@ def main(host='localhost', port=5432, schema=None):
 
     pswd = (args.password and getpass.getpass() or '')
     db = Database(args.dbname, args.username, pswd, args.host, args.port)
-    dbmap = db.to_map([args.schema], args.tablist)
+    dbmap = db.to_map(schemas=args.schema, tables=args.tablist,
+            exclude_schemas=args.exclude_schema,
+            exclude_tables=args.ex_tablist)
     if args.output:
         fd = args.output
         sys.stdout = fd


### PR DESCRIPTION
I've added several command line options to dbtoyaml command which allow specify which schemas/tables should be excluded from output.
- -N/--exclude-schema command line option allows to specify several schemas
  (via repeating option declaration) to exclude from output
- -T/--exclude-table command line option allows to specify several tables
  (via repeating option declaration) to exclude from output
- -n/--schema now allows to specify several schemas to include in output (via
  repeating option declaration).
- Database.to_map now doesn't treat schemas=[None] as special case
