### PR TITLE
Set pswd to None as default

### DIFF
--- a/pyrseas/dbtoyaml.py
+++ b/pyrseas/dbtoyaml.py
@@ -36,8 +36,8 @@ def main(host='localhost', port=5432, schema=None):
                         help="do NOT extract the named table(s) "
                        "(default none)")
 
-    parser.set_defaults(host=host, port=port, username=os.getenv("USER"),
-                        schema=schema)
+    parser.set_defaults(host=host, port=port, schema=schema,
+                        username=os.getenv("PGUSER") or os.getenv("USER"))
     args = parser.parse_args()
 
     pswd = (args.password and getpass.getpass() or None)

--- a/pyrseas/yamltodb.py
+++ b/pyrseas/yamltodb.py
@@ -30,7 +30,8 @@ def main(host='localhost', port=5432):
     parser.add_argument('-n', '--schema', dest='schlist', action='append',
                         help="only for named schemas (default all)")
 
-    parser.set_defaults(host=host, port=port, username=os.getenv("USER"))
+    parser.set_defaults(host=host, port=port,
+                        username=os.getenv("PGUSER") or os.getenv("USER"))
     args = parser.parse_args()
 
     pswd = (args.password and getpass.getpass() or None)


### PR DESCRIPTION
Set pswd to None as default (not empty string: '') in dbtoyaml.py and yamltodb.py, so that libpq could use PGPASSWORD environment variable. Namely in lib/dbconn.py "password=" is defined if pswd is not None, i.e. until now it was always defined, and libpq didn't fallback to environment variable.
