### PR TITLE
IndexDict.from_map: add oldname to enable index renaming.

### DIFF
--- a/pyrseas/dbobject/index.py
+++ b/pyrseas/dbobject/index.py
@@ -228,6 +228,8 @@ class IndexDict(DbObjectDict):
                 idx.unique = False
             if 'description' in val:
                 idx.description = val['description']
+            if 'oldname' in val:
+                idx.oldname = val['oldname']
             self[(table.schema, table.name, i)] = idx
 
     def diff_map(self, inindexes):


### PR DESCRIPTION
Index renaming didn't work because oldname attribute wasn't added to index object.
