### PR TITLE
Consistent naming of Augmenter function templates and segments - fixes #62

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,7 +47,7 @@ augmenter:
     modified_timestamp:
       not_null: true
       type: timestamp with time zone
-  func_templates:
+  function_templates:
     functempl_audit_default: |2-
 
       BEGIN

--- a/pyrseas/augment/audit.py
+++ b/pyrseas/augment/audit.py
@@ -60,7 +60,5 @@ class CfgAuditColumnDict(DbAugmentDict):
                 if attr == 'columns':
                     audcol.columns = [col for col in inaudcols[aud][attr]]
                 elif attr == 'triggers':
-                    audcol.triggers = {}
-                    for trg in inaudcols[aud][attr]:
-                        audcol.triggers.update(inaudcols[aud][attr][trg])
+                    audcol.triggers = [col for col in inaudcols[aud][attr]]
             self[audcol.name] = audcol

--- a/pyrseas/augment/function.py
+++ b/pyrseas/augment/function.py
@@ -85,6 +85,13 @@ class CfgFunctionSourceDict(DbAugmentDict):
             dct = {'source': src}
             self[templ] = CfgFunctionTemplate(name=templ, **dct)
 
+    def from_map(self, intempls):
+        """Initialize the dictionary of function templates by converting the input list
+
+        :param intempls: YAML list defining the function templates
+        """
+        for templ in intempls:
+            self[templ] = CfgFunctionTemplate(name=templ, source=intempls[templ])
 
 class CfgFunction(DbAugment):
     "A configuration function definition"

--- a/pyrseas/augmentdb.py
+++ b/pyrseas/augmentdb.py
@@ -42,8 +42,8 @@ class AugmentDatabase(Database):
             self.tables = AugClassDict()
             self.columns = CfgColumnDict(cfg_section(config, 'columns'))
             self.funcsrcs = CfgFunctionSourceDict(
-                cfg_section(config, 'func_templates'),
-                cfg_section(config, 'func_segments'))
+                cfg_section(config, 'function_templates'),
+                cfg_section(config, 'function_segments'))
             self.functions = CfgFunctionDict(cfg_section(config, 'functions'))
             self.triggers = CfgTriggerDict(cfg_section(config, 'triggers'))
             self.auditcols = CfgAuditColumnDict(
@@ -117,7 +117,7 @@ class AugmentDatabase(Database):
         for key in cfg_map:
             if key == 'columns':
                 self.adb.columns.from_map(cfg_map[key])
-            elif key in ['function templates', 'function segments']:
+            elif key in ['function_templates', 'function_segments']:
                 self.adb.funcsrcs.from_map(cfg_map[key])
             elif key == 'functions':
                 self.adb.functions.from_map(cfg_map[key])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ CFG_FILE = 'testcfg.yaml'
 def test_defaults():
     "Create a configuration with defaults"
     cfg = Config()
-    for key in ['audit_columns', 'functions', 'func_templates', 'columns',
+    for key in ['audit_columns', 'functions', 'function_templates', 'columns',
                 'triggers']:
         assert key in cfg['augmenter']
     for key in ['metadata', 'data']:


### PR DESCRIPTION
The commit also includes the missing `CfgFunctionSourceDict.from_map()` method and a change to `CfgAuditColumnDict.from_map()` to use a list of triggers instead of a dictionary, which matches how `config.yaml` is set up.

Do we need to reconsider how `triggers` are specified in the `audit_columns` section? Under what circumstances would we specify multiple triggers in the list?
