### PR TITLE
Encode output using utf-8

### DIFF
--- a/pyrseas/yamltodb.py
+++ b/pyrseas/yamltodb.py
@@ -48,9 +48,9 @@ def main():
             print("BEGIN;", file=fd)
         for stmt in stmts:
             if isinstance(stmt, tuple):
-                print("".join(stmt) + '\n', file=fd)
+                print(("".join(stmt) + '\n').encode('utf-8'), file=fd)
             else:
-                print("%s;\n" % stmt, file=fd)
+                print(("%s;\n" % stmt).encode('utf-8'), file=fd)
         if options.onetrans or options.update:
             print("COMMIT;", file=fd)
         if options.update:


### PR DESCRIPTION
When yamltodb is used with -u or printed to a terminal, there is no problem but if I try to output it into a file or a pipe, I have encoding problems. This quick and dirty patch encodes the output in utf-8.
