### PR TITLE
Do not alter an existing extension's owner since it is not valid.

### DIFF
--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -339,10 +339,11 @@ class DbObject(object):
         """
         return "ALTER %s %s RENAME TO %s" % (self.objtype, self.name, newname)
 
-    def diff_map(self, inobj):
+    def diff_map(self, inobj, no_owner=False):
         """Generate SQL to transform an existing object
 
         :param inobj: a YAML map defining the new object
+        :param no_owner: exclude object owner information
         :return: list of SQL statements
 
         Compares the object to an input object and generates SQL
@@ -351,7 +352,7 @@ class DbObject(object):
         comments.
         """
         stmts = []
-        if hasattr(inobj, 'owner') and hasattr(self, 'owner'):
+        if not no_owner and hasattr(inobj, 'owner') and hasattr(self, 'owner'):
             if inobj.owner != self.owner:
                 stmts.append(self.alter_owner(inobj.owner))
         stmts.append(self.diff_privileges(inobj))

--- a/pyrseas/dbobject/extension.py
+++ b/pyrseas/dbobject/extension.py
@@ -94,9 +94,10 @@ class ExtensionDict(DbObjectDict):
                     stmts.append(inexten.create())
                 else:
                     stmts.append(self[ext].rename(inexten))
+            # check extension objects
             else:
-                # check extension objects
-                stmts.append(self[ext].diff_map(inexten))
+                # extension owner cannot be altered, set no_owner to True
+                stmts.append(self[ext].diff_map(inexten, no_owner=True))
 
         # check existing extensions
         for ext in self:

--- a/tests/dbobject/test_extension.py
+++ b/tests/dbobject/test_extension.py
@@ -117,3 +117,18 @@ class ExtensionToSqlTestCase(InputMapToSqlTestCase):
             'schema': 'public', 'description': "Trigram extension"}})
         sql = self.to_sql(inmap, [CREATE_STMT], superuser=True)
         assert sql == ["COMMENT ON EXTENSION pg_trgm IS 'Trigram extension'"]
+
+    def test_no_alter_owner_extension(self):
+        """Do not alter the owner of an existing extension.
+
+        ALTER EXTENSION extension_name OWNER is not a valid form.
+        """
+        if self.db.version < 90100:
+            self.skipTest('Only available on PG 9.1')
+        # create a new owner that is different from self.db.user
+        new_owner = 'new_%s' % self.db.user
+        inmap = self.std_map()
+        inmap.update({'extension pg_trgm': {'schema': 'public', 'owner': new_owner}})
+        sql = self.to_sql(inmap, [CREATE_STMT], superuser=True)
+        assert 'ALTER EXTENSION pg_trgm OWNER TO %s' % new_owner not in sql
+


### PR DESCRIPTION
Add a no_owner kwarg to  DbObject.diff_map, such that when its
value is True it ignores owner comparison, and generation of an
alter statement.

Refs: pyrseas/Pyrseas#88
