### PR TITLE
Query for constraints with table names > 55 chars

### DIFF
--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -282,8 +282,8 @@ class ConstraintDict(DbObjectDict):
     cls = Constraint
     query = \
         """SELECT nspname AS schema,
-                  CASE WHEN contypid = 0 THEN conrelid::regclass::name
-                       ELSE contypid::regtype::name END AS table,
+                  CASE WHEN contypid = 0 THEN conrelid::regclass::text
+                       ELSE contypid::regtype::text END AS table,
                   conname AS name,
                   CASE WHEN contypid != 0 THEN 'd' ELSE '' END AS target,
                   contype AS type, conkey AS keycols,


### PR DESCRIPTION
Casting conrelid::regclass::name truncates long table names (> 55 chars) -- casting instead as conrelid::regclass::text fixes the problem.
