### PR TITLE
Issue141

### DIFF
--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -482,6 +482,8 @@ class DbObjectDict(dict):
         for obj in self.fetch():
             if hasattr(obj, 'privileges'):
                 obj.privileges = obj.privileges.split(',')
+            if hasattr(obj, 'options'):
+                obj.options = sorted(obj.options)
             self[obj.key()] = obj
 
     def to_map(self,  opts):

--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -294,7 +294,10 @@ class DbObject(object):
         owner = self.owner if hasattr(self, 'owner') else ''
         for prv in self.privileges:
             privlist.append(privileges_to_map(prv, self.allprivs, owner))
-        return privlist
+        sorted_privlist = []
+        for sortedItem in sorted([list(i.keys())[0] for i in privlist]):
+            sorted_privlist.append([item for item in privlist if list(item.keys())[0] == sortedItem][0])
+        return sorted_privlist
 
     def _comment_text(self):
         """Return the text for the SQL COMMENT statement


### PR DESCRIPTION
I've made fixes for [issue 141](https://github.com/perseas/Pyrseas/issues/141). Fixed  sorting order for:
1. priviledges in DbObject.map_privs
2. options in DbObjectDict._from_catalog (problem was there, but not in pyrseas/dbobject/foreign.py)