### PR TITLE
Don't use an hardcoded path for the Python interpreter in scrips

### DIFF
--- a/pyrseas/dbaugment.py
+++ b/pyrseas/dbaugment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """dbaugment - Augment a PostgreSQL database"""
 

--- a/pyrseas/dbtoyaml.py
+++ b/pyrseas/dbtoyaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """dbtoyaml - extract the schema of a PostgreSQL database in YAML format"""
 

--- a/pyrseas/yamltodb.py
+++ b/pyrseas/yamltodb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """yamltodb - generate SQL statements to update a PostgreSQL database
 to match the schema specified in a YAML file"""


### PR DESCRIPTION
Allow using the python currenly in the path, e.g. using virtualenv