### PR TITLE
Make code Python 2.6 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "2.7"
+  - "2.6"
 addons:
   postgresql: "9.5"
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Requirements
 
 - PostgreSQL 9.2 or higher
 
-- Python 2.7 or higher
+- Python 2.6 or higher
 
 License
 -------

--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -193,7 +193,7 @@ class PrimaryKey(Constraint):
            and hasattr(self, '_table') and hasattr(self._table, 'columns') \
            and hasattr(self._table, 'primary_key') and \
            hasattr(self._table.primary_key, 'keycols'):
-            selfcols = {i.number: i.name for i in self._table.columns}
+            selfcols = dict((i.number, i.name) for i in self._table.columns)
             selfpk = [selfcols[i] for i in self._table.primary_key.keycols]
             if inpk.keycols != selfpk:
                 stmts.append(
@@ -303,9 +303,9 @@ class ForeignKey(Constraint):
            and hasattr(self, '_table') and hasattr(self._table, 'columns') \
            and hasattr(self, 'references') \
            and hasattr(self.references, 'columns'):
-            selfcols = {i.number: i.name for i in self._table.columns}
+            selfcols = dict((i.number, i.name) for i in self._table.columns)
             selffk = [selfcols[i] for i in self.keycols]
-            selfrefs = {i.number: i.name for i in self.references.columns}
+            selfrefs = dict((i.number, i.name) for i in self.references.columns)
             selffkref = [selfrefs[i] for i in self.ref_cols]
 
             if infk.keycols != selffk or infk.ref_cols != selffkref \
@@ -403,7 +403,7 @@ class UniqueConstraint(Constraint):
         stmts = []
         if hasattr(inuc, 'keycols') and hasattr(self, 'keycols') \
            and hasattr(self, '_table') and hasattr(self._table, 'columns'):
-            selfcols = {i.number: i.name for i in self._table.columns}
+            selfcols = dict((i.number, i.name) for i in self._table.columns)
             selfunique = [selfcols[i] for i in self.keycols]
             if inuc.keycols != selfunique:
                 stmts.append(

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+[pg96]
+setenv =
+    PYRSEAS_TEST_PORT={env:PG96_PORT}
+
 [pg95]
 setenv =
     PYRSEAS_TEST_PORT={env:PG95_PORT}
@@ -13,6 +17,36 @@ setenv =
 [pg92]
 setenv =
     PYRSEAS_TEST_PORT={env:PG92_PORT}
+
+[testenv:py26pg96]
+basepython=python2.6
+envdir={toxworkdir}/py26
+setenv = {[pg96]setenv}
+
+[testenv:py26pg95]
+basepython=python2.6
+envdir={toxworkdir}/py26
+setenv = {[pg95]setenv}
+
+[testenv:py26pg94]
+basepython=python2.6
+envdir={toxworkdir}/py26
+setenv = {[pg94]setenv}
+
+[testenv:py26pg93]
+basepython=python2.6
+envdir={toxworkdir}/py26
+setenv = {[pg93]setenv}
+
+[testenv:py26pg92]
+basepython=python2.6
+envdir={toxworkdir}/py26
+setenv = {[pg92]setenv}
+
+[testenv:py27pg96]
+basepython=python2.7
+envdir={toxworkdir}/py27
+setenv = {[pg96]setenv}
 
 [testenv:py27pg95]
 basepython=python2.7
@@ -33,6 +67,11 @@ setenv = {[pg93]setenv}
 basepython=python2.7
 envdir={toxworkdir}/py27
 setenv = {[pg92]setenv}
+
+[testenv:py35pg96]
+basepython=python3.5
+envdir={toxworkdir}/py35
+setenv = {[pg96]setenv}
 
 [testenv:py35pg95]
 basepython=python3.5


### PR DESCRIPTION
On some environments (CentOS 6, RHEL 6) python 2.6 is only available by
default.

I'm hoping you're willing to consider adding python 2.6. The only real code change is in Dictionary and set comprehensions.