### PR TITLE
PostgreSQL 10 compatibility

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -600,7 +600,7 @@ class DbObjectDict(dict):
     def __init__(self, dbconn=None):
         """Initialize the dictionary
 
-        :param dbconn: a DbConnection object
+        :param pgdbconn.dbconn.DbConnection dbconn: a DbConnection object
 
         If dbconn is not None, the _from_catalog method is called to
         initialize the dictionary from the catalogs.

--- a/pyrseas/dbobject/trigger.py
+++ b/pyrseas/dbobject/trigger.py
@@ -196,8 +196,16 @@ class Trigger(DbSchemaObject):
         # has always none (they are accessed through `tg_argv`).
         # TODO: this breaks if a function name contains a '('
         # (another case for a robust lookup function in db)
-        fschema, fname = split_schema_obj(self.procedure, self.schema)
-        fname, _ = fname.split('(', 1)  # implicitly assert there is a (
+        fschema, fullfname = split_schema_obj(self.procedure, self.schema)
+        fullfname, _ = fullfname.split('(', 1)  # implicitly assert there is a (
+        # workaround when trigger function lies in schema different from table
+        fullfname = fullfname.split(".")
+        if len(fullfname) == 2:
+            fschema = fullfname[0]
+            fname = fullfname[1]
+        else:
+            fschema = 'public'
+            fname = fullfname[0]
         if not fname.startswith('tsvector_update_trigger'):
             deps.add(db.functions[fschema, fname, ''])
 

--- a/tests/dbobject/test_trigger.py
+++ b/tests/dbobject/test_trigger.py
@@ -227,10 +227,10 @@ class TriggerToSqlTestCase(InputMapToSqlTestCase):
                             {'c3': {'type': 'timestamp with time zone'}}],
                 'triggers': {'tr1': {
                     'timing': 'before', 'events': ['insert', 'update'],
-                    'level': 'row', 'procedure': 'f1()'}}}}})
+                    'level': 'row', 'procedure': 's1.f1()'}}}}})
         sql = self.to_sql(inmap, ["CREATE SCHEMA s1"])
         assert fix_indent(sql[2]) == "CREATE TRIGGER tr1 BEFORE INSERT OR " \
-            "UPDATE ON s1.t1 FOR EACH ROW EXECUTE PROCEDURE f1()"
+            "UPDATE ON s1.t1 FOR EACH ROW EXECUTE PROCEDURE s1.f1()"
 
     def test_drop_trigger(self):
         "Drop an existing trigger"


### PR DESCRIPTION
Added PostgreSQL 10 compatibility (no new features, only that are supported by 9.6):

* fixed sequence support.
* fixed problems in constraints when table's name is a reserved word (like "order") and shoul be in '"'
* fixed a problem when trigger function lies in schema different from table's one
* fixed trigger test for non-public schema