### PR TITLE
Remove deepcopy for mapping columns into yaml

### DIFF
--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -321,7 +321,7 @@ class DbObject(object):
         """
         return quote_id(self.__dict__[self.keylist[0]])
 
-    def to_map(self, db, no_owner=False, no_privs=False):
+    def to_map(self, db, no_owner=False, no_privs=False, deepcopy=True):
         """Convert an object to a YAML-suitable format
 
         :param db: db used to tie the objects together
@@ -333,7 +333,10 @@ class DbObject(object):
         or JSON object.
         """
         import copy
-        dct = copy.deepcopy(self.__dict__)
+        if deepcopy:
+            dct = copy.deepcopy(self.__dict__)
+        else:
+            dct = self.__dict__.copy()
         for key in self.keylist:
             del dct[key]
         if self.description is None:

--- a/pyrseas/dbobject/column.py
+++ b/pyrseas/dbobject/column.py
@@ -121,7 +121,7 @@ class Column(DbSchemaObject):
         """
         if self.dropped:
             return None
-        dct = super(Column, self).to_map(db, False, no_privs)
+        dct = super(Column, self).to_map(db, False, no_privs, deepcopy=False)
         del dct['number'], dct['name'], dct['dropped']
         if not self.not_null:
             dct.pop('not_null')


### PR DESCRIPTION
When dumping large database I noticed that some invocations
took a long time. While profiling I saw something like the following:

14923209 function calls (11611900 primitive calls) in 6.139 seconds

90% copy.py:145(deepcopy)
88% table.py:466(to_map)
81% column.py:116(to_map)
 3% __init__.py:668(fetch) (Reading the PostgreSQL catalog)
The column attributes don't require a deep copy as they are all scalar
values. After applying this fix, we can see the following:

1582104 function calls (1329521 primitive calls) in 0.944 seconds

46% copy.py:145(deepcopy)
51% table.py:466(to_map)
 3% column.py:116(to_map)
21% __init__.py:670(fetch) (Reading the PostgreSQL catalog)