### PR TITLE
Do not assume a constraint has columns

### DIFF
--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -181,7 +181,7 @@ class CheckConstraint(Constraint):
         dct.pop('is_domain_check')
         if not self.inherited:
             dct.pop('inherited')
-        if dbcols is not None:
+        if dbcols is not None and self.columns is not None:
             dct['columns'] = [dbcols[k - 1] for k in self.columns]
         else:
             dct.pop('columns')


### PR DESCRIPTION
When specifying a constraint like:

```sql
CREATE TABLE demo (
    i integer,
    CONSTRAINT demo_check CHECK (false) NO INHERIT
);
```

The to_map function raised the following error:

TypeError: 'NoneType' object is not iterable

As creating a CHECK constraint which does not reference a
column is valid, and sometimes useful (as the above is
useful in inherited tables) ensure we only fill columns if
columns can be found.