### PR TITLE
Update Travis config for expanded coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,42 @@
 language: python
-python:
-  - "3.6"
-  - "2.7"
+
 addons:
-  postgresql: "9.6"
+  apt:
+    update: true
+    packages: postgresql-common
+    sources:
+    - sourceline: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+
+jobs:
+  include:
+  - python: "2.7"
+    env: POSTGRES=9.6
+  - python: "3.6"
+    env: POSTGRES=10
+
+# Ensure the desired version of Postgres is installed and running
+# Most of this is normally handled by Travis automatically, but only for certain versions of Postgres
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_postgresql.bash
 before_install:
-  - export PATH=/usr/lib/postgresql/9.6/bin:$PATH
+  - sudo systemctl stop postgresql
+  - aptInst() { sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install $*; }
+  - aptInst postgresql-$POSTGRES postgresql-plperl-$POSTGRES
+  - aptInst postgresql-plpython-$POSTGRES
+  # the port may have been auto-configured to use 5433 if it thought 5422 was already in use
+  - sudo sed -i -e 's/5433/5432/' /etc/postgresql/*/main/postgresql.conf
+  - sudo mkdir -p /var/ramfs/postgresql
+  - if [ ! -d /var/ramfs/postgresql/$POSTGRES ]; then sudo cp -rp /var/lib/postgresql/$POSTGRES /var/ramfs/postgresql/$POSTGRES; fi
+  - sudo systemctl start postgresql@$POSTGRES-main
+  - (cd /; sudo -u postgres createuser -e -s travis || echo failed createuser)
+  - (cd /; sudo -u postgres createdb -e -O travis travis || echo failed created)
+
+# Ensure Postgres is configured as described in docs/testing.rst
+before_script:
   - sudo locale-gen --no-archive fr_FR.UTF-8
   - sudo mkdir -p /extra/pg/ts1 /extra/pg/ts2
   - sudo chown postgres:postgres /extra/pg/ts1 /extra/pg/ts2
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq postgresql-plperl-9.6 postgresql-plpython-9.6
-before_script:
   - psql -Upostgres -c "CREATE TABLESPACE ts1 LOCATION '/extra/pg/ts1'"
   - psql -Upostgres -c "CREATE TABLESPACE ts2 LOCATION '/extra/pg/ts2'"
+
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ jobs:
     env: POSTGRES=10
   - python: "3.7"
     env: POSTGRES=11
+  - python: "3.8"
+    env: POSTGRES=12
+  allow_failures:
+    - env: POSTGRES=12
 
 # Ensure the desired version of Postgres is installed and running
 # Most of this is normally handled by Travis automatically, but only for certain versions of Postgres
@@ -27,7 +31,8 @@ before_install:
   - sudo systemctl stop postgresql
   - aptInst() { sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install $*; }
   - aptInst postgresql-$POSTGRES postgresql-plperl-$POSTGRES
-  - aptInst postgresql-plpython-$POSTGRES
+  # Postgres 12+ doesn't publish a plpython extension, only plpython3
+  - if [ "$POSTGRES" != "12" ]; then aptInst postgresql-plpython-$POSTGRES; fi
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use
   - sudo sed -i -e 's/5433/5432/' /etc/postgresql/*/main/postgresql.conf
   # postgresql-11+ default to "peer"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
 jobs:
   include:
   - python: "2.7"
+    env: POSTGRES=9.4
+  - python: "2.7"
+    env: POSTGRES=9.5
+  - python: "2.7"
     env: POSTGRES=9.6
   - python: "3.6"
     env: POSTGRES=10

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ jobs:
     env: POSTGRES=9.6
   - python: "3.6"
     env: POSTGRES=10
+  - python: "3.7"
+    env: POSTGRES=11
 
 # Ensure the desired version of Postgres is installed and running
 # Most of this is normally handled by Travis automatically, but only for certain versions of Postgres
@@ -24,6 +26,8 @@ before_install:
   - aptInst postgresql-plpython-$POSTGRES
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use
   - sudo sed -i -e 's/5433/5432/' /etc/postgresql/*/main/postgresql.conf
+  # postgresql-11+ default to "peer"
+  - sudo sed -i -E -e 's/^local\s+all\s+postgres\s+peer/local all postgres trust/' /etc/postgresql/*/main/pg_hba.conf
   - sudo mkdir -p /var/ramfs/postgresql
   - if [ ! -d /var/ramfs/postgresql/$POSTGRES ]; then sudo cp -rp /var/lib/postgresql/$POSTGRES /var/ramfs/postgresql/$POSTGRES; fi
   - sudo systemctl start postgresql@$POSTGRES-main

--- a/tests/functional/test_pagila.py
+++ b/tests/functional/test_pagila.py
@@ -22,6 +22,8 @@ class PagilaTestCase(DbMigrateTestCase):
         cls.remove_tempfiles('empty')
 
     def test_pagila(self):
+        if self.db.version < 90600:
+            self.skipTest('Only available on PG 9.6 and later')
         # Create the source schema
         self.execute_script(__file__, 'pagila-schema.sql')
 


### PR DESCRIPTION
While playing around with #212 I wanted to make sure I could adequately test my changes.

This updates the Travis config to cover all the major versions of Python and Postgres that are readily available.