### PR TITLE
Quote more keywords in SQL generation

### DIFF
--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -36,7 +36,7 @@ def fetch_reserved_words(db):
     if len(RESERVED_WORDS) == 0:
         RESERVED_WORDS = [word[0] for word in
                           db.fetchall("""SELECT word FROM pg_get_keywords()
-                                         WHERE catcode = 'R'""")]
+                                         WHERE catcode != 'U'""")]
 
 
 def quote_id(name):


### PR DESCRIPTION
Change filter to use any keywords not marked as non-reserved instead of
only those marked as reserved. This is necessary due to how certain
keywords are classified by Postgres and by the various standards.

Keyword categories (from Postgres `src/include/common/keywords.h`):
- `U` / `UNRESERVED_KEYWORD`
- `C` / `COL_NAME_KEYWORD`
- `T` / `TYPE_FUNC_NAME_KEYWORD`
- `R` / `RESERVED_KEYWORD`

For example, "authorization" is reserved, but may be used as a function
name, so it has a `catcode` of `T` instead of `R`, so is not quoted by
the original logic.

Docs: https://www.postgresql.org/docs/current/sql-keywords-appendix.html

Closes #212