### PR TITLE
Use pg_available_extensions() instead of pg_pltemplate for postgres 13 compatibility

### DIFF
--- a/pyrseas/database.py
+++ b/pyrseas/database.py
@@ -522,7 +522,7 @@ class Database(object):
             fetch_reserved_words(self.dbconn)
 
         langs = [lang[0] for lang in self.dbconn.fetchall(
-            "SELECT tmplname FROM pg_pltemplate")]
+            "SELECT name FROM pg_available_extensions() INNER JOIN pg_language ON name = lanname;")]
         self.from_map(input_map, langs)
         if opts.revert:
             (self.db, self.ndb) = (self.ndb, self.db)


### PR DESCRIPTION
See #226 

pg_pltemplate was removed in postgres 13. We can query from
pg_available_extensions() and join with pg_language to find out which
language extensions are installed.
https://www.postgresql.org/docs/13/release-13.html#id-1.11.6.7.5.14