### PR TITLE
docs: fix simple typo, ouput -> output

### DIFF
--- a/docs/yamltodb.rst
+++ b/docs/yamltodb.rst
@@ -121,7 +121,7 @@ or::
 
   yamltodb --update mymovies moviesdb.yaml
 
-To generate the statements directly from the ouput of
+To generate the statements directly from the output of
 :program:`dbtoyaml` (against a different database), with statements
 enclosed in a single transaction, and save the statements in a file
 named ``mymovies.sql``::


### PR DESCRIPTION
There is a small typo in docs/yamltodb.rst.

Should read `output` rather than `ouput`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md