### PR TITLE
Faster deepcopy

### DIFF
--- a/pyrseas/dbobject/__init__.py
+++ b/pyrseas/dbobject/__init__.py
@@ -337,9 +337,9 @@ class DbObject(object):
         The return value, a Python dictionary, is equivalent to a YAML
         or JSON object.
         """
-        import copy
+        import pickle
         if deepcopy:
-            dct = copy.deepcopy(self.__dict__)
+            dct = pickle.loads(pickle.dumps(self.__dict__, -1))
         else:
             dct = self.__dict__.copy()
         for key in self.keylist:


### PR DESCRIPTION
Profiling my setup I noticed I was spending a lot of time in this deepcopy call.

Looking at this: https://stackoverflow.com/questions/24756712/deepcopy-is-extremely-slow#answer-29385667
Using `pickle` to copy objects is simple approach to getting a faster copy of objects.

I tested this and it gave a 50% faster time when dumping out one table. From 2.6-2.8s to 1.1-1.2s.