### PR TITLE
Omit deepcopy for constraints and tables

### DIFF
--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -11,6 +11,8 @@
     TODO: UniqueConstraint and PrimaryKey are nearly identical.
           Perhaps the latter should inherit from the former.
 """
+import copy
+
 from . import DbObjectDict, DbSchemaObject
 from . import quote_id, split_schema_obj, commentable
 from .index import Index
@@ -176,7 +178,7 @@ class CheckConstraint(Constraint):
         :param dbcols: dictionary of dbobject columns
         :return: dictionary
         """
-        dct = super(CheckConstraint, self).to_map(db)
+        dct = super(CheckConstraint, self).to_map(db, deepcopy=False)
         dct.pop('is_domain_check')
         if not self.inherited:
             dct.pop('inherited')
@@ -184,7 +186,7 @@ class CheckConstraint(Constraint):
             dct['columns'] = [dbcols[k - 1] for k in self.columns]
         else:
             dct.pop('columns')
-        return {self.name: dct}
+        return {self.name: copy.deepcopy(dct)}
 
     @commentable
     def add(self):
@@ -308,7 +310,7 @@ class PrimaryKey(Constraint):
         :param dbcols: dictionary of dbobject columns
         :return: dictionary
         """
-        dct = super(PrimaryKey, self).to_map(db)
+        dct = super(PrimaryKey, self).to_map(db, deepcopy=False)
         if self.access_method == 'btree':
             dct.pop('access_method')
         for attr in ('inherited', 'deferrable', 'deferred', 'cluster'):
@@ -319,7 +321,7 @@ class PrimaryKey(Constraint):
         if '_table' in dct:
             del dct['_table']
         dct['columns'] = [dbcols[k - 1] for k in self.columns]
-        return {self.name: dct}
+        return {self.name: copy.deepcopy(dct)}
 
     def alter(self, inpk):
         """Generate SQL to transform an existing primary key
@@ -486,7 +488,7 @@ class ForeignKey(Constraint):
         :return: dictionary
         """
         self._normalize_columns()
-        dct = super(ForeignKey, self).to_map(db)
+        dct = super(ForeignKey, self).to_map(db, deepcopy=False)
         if '_table' in dct:
             del dct['_table']
         if self.access_method == 'btree':
@@ -507,7 +509,7 @@ class ForeignKey(Constraint):
         dct.pop('ref_table')
         dct.pop('ref_cols')
 
-        return {self.name: dct}
+        return {self.name: copy.deepcopy(dct)}
 
     @commentable
     def add(self):
@@ -673,7 +675,7 @@ class UniqueConstraint(Constraint):
         :return: dictionary
         """
         self._normalize_columns()
-        dct = super(UniqueConstraint, self).to_map(db)
+        dct = super(UniqueConstraint, self).to_map(db, deepcopy=False)
         if self.access_method == 'btree':
             dct.pop('access_method')
         for attr in ('inherited', 'deferrable', 'deferred', 'cluster'):
@@ -681,7 +683,7 @@ class UniqueConstraint(Constraint):
                 dct.pop(attr)
         if self.tablespace is None:
             dct.pop('tablespace')
-        return {self.name: dct}
+        return {self.name: copy.deepcopy(dct)}
 
     def alter(self, inuc):
         """Generate SQL to transform an existing unique constraint

--- a/pyrseas/dbobject/table.py
+++ b/pyrseas/dbobject/table.py
@@ -8,6 +8,7 @@
     ClassDict derived from DbObjectDict.
 """
 
+import copy
 import re
 import os
 import sys
@@ -460,7 +461,8 @@ class Table(DbClass):
                 and self.name in opts.excl_tables or len(self.columns) == 0:
             return None
 
-        dct = super(Table, self).to_map(db, opts.no_owner, opts.no_privs)
+        dct = super(Table, self).to_map(db, opts.no_owner, opts.no_privs,
+                                        deepcopy=False)
 
         for attr in ('tablespace', 'options', 'partition_bound_spec'):
             if dct[attr] is None:
@@ -493,6 +495,7 @@ class Table(DbClass):
         dct.pop('partition_exprs')
 
         if len(self.check_constraints) > 0:
+            dct['check_constraints'] = copy.copy(dct['check_constraints'])
             for k in list(self.check_constraints.values()):
                 dct['check_constraints'].update(
                     self.check_constraints[k.name].to_map(
@@ -505,6 +508,7 @@ class Table(DbClass):
         else:
             dct.pop('primary_key')
         if len(self.foreign_keys) > 0:
+            dct['foreign_keys'] = copy.copy(dct['foreign_keys'])
             for k in list(self.foreign_keys.values()):
                 tbls = dbschemas[k.ref_schema].tables
                 ktable = self.foreign_keys[k.name]
@@ -514,6 +518,7 @@ class Table(DbClass):
         else:
             dct.pop('foreign_keys')
         if len(self.unique_constraints) > 0:
+            dct['unique_constraints'] = copy.copy(dct['unique_constraints'])
             for k in list(self.unique_constraints.values()):
                 dct['unique_constraints'].update(
                     self.unique_constraints[k.name].to_map(
@@ -533,17 +538,19 @@ class Table(DbClass):
         else:
             dct.pop('indexes')
         if len(self.rules) > 0:
+            dct['rules'] = copy.copy(dct['rules'])
             for k in list(self.rules.values()):
                 dct['rules'].update(self.rules[k.name].to_map(db))
         else:
             dct.pop('rules')
         if len(self.triggers) > 0:
+            dct['triggers'] = copy.copy(dct['triggers'])
             for k in list(self.triggers.values()):
                 dct['triggers'].update(self.triggers[k.name].to_map(db))
         else:
             dct.pop('triggers')
 
-        return dct
+        return copy.deepcopy(dct)
 
     def create(self, dbversion=None):
         """Return SQL statements to CREATE the table


### PR DESCRIPTION
It looks like invoking deepcopy on all fields for constraints and tables takes a significant amount of time, since we end up copying nested objects that we don't care about in the final result.

Instead, we can copy only the dictionaries that we're going to modify, and then deepcopy the final result (which is going to be much smaller).

The difference is drastic: on my database (250+ tables), this speeds up dbtoyaml from 70 seconds to **1.2 seconds**, with the same final YAML generated.

