### PR TITLE
the CheckConstraint query returned constraints owned by extensions

### DIFF
--- a/pyrseas/dbobject/constraint.py
+++ b/pyrseas/dbobject/constraint.py
@@ -148,6 +148,8 @@ class CheckConstraint(Constraint):
               AND contype = 'c'
               AND contypid NOT IN (SELECT objid FROM pg_depend
                   WHERE deptype = 'e' AND classid = 'pg_type'::regclass)
+              AND conrelid NOT IN (SELECT objid FROM pg_depend
+                  WHERE deptype = 'e' AND classid = 'pg_class'::regclass)
             ORDER BY schema, "table", name"""
 
     @staticmethod


### PR DESCRIPTION
The fact that CheckConstraints created by extensions were not filtered out was causing an error when calling `db.to_map()` for a db with the postgis extension (since the db table referenced by the check constraint is not in the list of tables as it was correctly filtered out).

I see similar issues mentioned here: https://github.com/perseas/Pyrseas/issues/236